### PR TITLE
shipit.yml

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+  override:
+    - rake build
+    - package_cloud push shopify/prodeng-gems pkg/ruby-junos-ez-stdlib-*.gem


### PR DESCRIPTION
@dwradcliffe @charlescng 
This is to publish it to prodeng-gems(https://packages.shopify.io/shopify/prodeng-gems).

I got this error when trying to add `network_automation` in cookbooks:

```
peiwen@netops-01.ash:/usr/lib/shopify-ruby/2.1.6-shopify2/lib/ruby/gems/2.1.0/gems/network_automation-0.0.3 $ bin/collect_networks 
fatal: Not a git repository (or any of the parent directories): .git
git@github.com:Shopify/ruby-junos-ez-stdlib (at 36907eb) is not yet checked out. Run `bundle install` first.
```

If we publish this repo to private gem server, then I can add `ruby-junos-ez-stdlib` as dependency in `network_automation` gemspec file, then I dont need to worry about the dependency issues in cookbook changes.
