### PR TITLE
publish it to rubygems

### DIFF
--- a/junos-ez-stdlib.gemspec
+++ b/junos-ez-stdlib.gemspec
@@ -3,7 +3,7 @@ require 'rake'
 require 'junos-ez/version'
 
 Gem::Specification.new do |s|
-  s.name = 'junos-ez-stdlib'
+  s.name = 'shopify-junos-ez-stdlib'
   s.version = Junos::Ez::VERSION
   s.summary = "Junos EZ Framework - Standard Libraries"
   s.description = "Automation Framework for Junos/NETCONF:  Facts, Providers, and Utils"

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,0 @@
-deploy:
-  override:
-    - rake build
-    - package_cloud push shopify/prodeng-gems pkg/ruby-junos-ez-stdlib-*.gem


### PR DESCRIPTION
@dwradcliffe @charlescng 
`Network_automation` is depending on this gem.
And we cannot resolve the dependency if this gem is in prodeng private cloud.

Push it to rubygems, and then we can easily use it in `network_automation`, and there will be no dependency issue in chef. 

https://rubygems.org/gems/shopify-junos-ez-stdlib
