### PR TITLE
Update bundler to 2.0.2 and add dev support

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,6 @@
+# This file is for shopify internal development, feel free to ignore.
+name: ruby-junos-ez-stdlib
+
+up:
+  - ruby: 2.5.3
+  - bundler

--- a/junos-ez-stdlib.gemspec
+++ b/junos-ez-stdlib.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('netconf', '~> 0.3.1')
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.49.0'


### PR DESCRIPTION
- Shipit requires bundler 2.0+
- Add dev support